### PR TITLE
Mail encoding and force content in all contact forms

### DIFF
--- a/templates/contact/contact.php
+++ b/templates/contact/contact.php
@@ -37,6 +37,7 @@
 function sendMail($yellow, $spamFilter)
 {
 	$ok = true;
+	if(empty($_REQUEST['name']) || empty($_REQUEST["from"]) || empty($_REQUEST["message"])) $ok = false; // field validation
 	if(!empty($_REQUEST["from"]) && !filter_var($_REQUEST["from"], FILTER_VALIDATE_EMAIL)) $ok = false;
 	if(!empty($_REQUEST["message"]) && preg_match("/$spamFilter/", $_REQUEST["message"])) $ok = false;
 	$mailName = preg_replace("/[^\w\-\.\@ ]/", "-", $_REQUEST["name"]);
@@ -45,7 +46,8 @@ function sendMail($yellow, $spamFilter)
 	if($yellow->config->isExisting("contactEmail")) $mailTo = $yellow->config->get("contactEmail");
 	$mailSubject = $yellow->page->get("title");
 	$mailMessage = $_REQUEST["message"]."\r\n-- \r\n$mailName";
-	$mailHeaders = "From: ".(empty($mailFrom) ? "noreply" : (empty($mailName) ? "$mailFrom" : "$mailFrom ($mailName)"))."\r\n";
+	$mailHeaders = "Content-Type: text/plain; charset=UTF-8;\r\n";
+	$mailHeaders .= "From: ".(empty($mailFrom) ? "noreply" : (empty($mailName) ? "$mailFrom" : "$mailFrom ($mailName)"))."\r\n";
 	$mailHeaders .= "X-Contact-Url: ".$yellow->page->getUrl()."\r\n";
 	$mailHeaders .= "X-Remote-Addr: ".$_SERVER["REMOTE_ADDR"]."\r\n";
 	if($ok) $ok = mail($mailTo, $mailSubject, $mailMessage, $mailHeaders);


### PR DESCRIPTION
As a workaround for the validation of contact form input. Also encoding with german umlauts work now.